### PR TITLE
Fix for closure issue.

### DIFF
--- a/mcp23017/mcp23017.js
+++ b/mcp23017/mcp23017.js
@@ -13,95 +13,100 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+module.exports = function(RED) {
+    var MCP = require("node-mcp23017");
+    String.prototype.endsWith = function(suffix) {
+        return this.match(suffix + "$") == suffix;
+    };
 
+    function mcp23017_Node(config) {
+        RED.nodes.createNode(this, config);
 
- module.exports = function(RED)
- {
- 	var MCP = require("node-mcp23017");
-		String.prototype.endsWith = function(suffix) {
-		    return this.match(suffix+"$") == suffix;
-		};
+        this.topic = config.topic;
+        if (this.topic.endsWith("/") == false)
+            this.topic += '/';
 
- 	function mcp23017_Node(config) {
- 		RED.nodes.createNode(this, config);
+        var node = this;
 
- 		this.topic = config.topic;
- 		if (this.topic.endsWith("/") == false)
- 			this.topic += '/';
+        var icAddress = parseInt(config.address);
 
- 		var node   = this;
+        var mcp = new MCP({
+            address: icAddress, //all address pins pulled low
+            device: config.device, // Model B
+            debug: false
+        });
 
- 		var icAddress = parseInt(config.address);
+        //set all GPIOS to be OUTPUTS
+        for (var i = 0; i < 16; i++) {
+            mcp.pinMode(i, mcp.OUTPUT);
+            mcp.digitalWrite(i, mcp.HIGH);
+        }
 
- 		var mcp = new MCP({
-  			address: icAddress, 	//all address pins pulled low
-  			device:  config.device, // Model B
-  			debug: false
-  		});
+        this.on('input', function(msg) {
+            this.status({
+                fill: "red",
+                shape: "dot",
+                text: "Busy`"
+            });
+            if (msg.topic.toUpperCase().indexOf('ALL') > -1) {
+                mcp23017_set_all_outputs(msg.payload);
+                send_status_message("ALL", node.topic + pin, msg.payload);
+            } else if (msg.topic.toUpperCase().indexOf('STATUS') > -1) {
+                mcp23017_send_status();
+            } else {
+                var pin = get_pin_from_topic(msg.topic);
+                if (pin >= 0 && pin < 16) {
+                    mcp23017_process(pin, msg.payload);
+                    send_status_message(pin, node.topic + pin, msg.payload);
+                } else {
+                    node.warn("Topic should contain a valid pin in the rannge 0..15: [" + msg.topic + "]");
+                }
+            }
+            this.status({
+                fill: "green",
+                shape: "dot",
+                text: "Ready"
+            });
+        });
 
-		//set all GPIOS to be OUTPUTS
-		for (var i = 0; i < 16; i++) {
-			mcp.pinMode(i, mcp.OUTPUT);
-			mcp.digitalWrite(i, mcp.HIGH);
-		}
+        function send_status_message(pin, topic, state) {
+            var statusMsg = {}
+            statusMsg.topic = topic + pin;
+            statusMsg.payload = "Sent " + state + " to relay " + pin;
+            node.send(statusMsg);
+        }
 
-		this.on('input', function(msg) {
-			this.status({fill:"red",shape:"dot",text:"Busy`"});
-			if (msg.topic.toUpperCase().indexOf('ALL')>-1) {
-				mcp23017_set_all_outputs(msg.payload);
-				send_status_message("ALL", node.topic + pin, msg.payload);
-			}
-			else if (msg.topic.toUpperCase().indexOf('STATUS')>-1) {
-				mcp23017_send_status();
-			}
-			else {
-				var pin = get_pin_from_topic(msg.topic);
-				if (pin >= 0 && pin < 16) {
-					mcp23017_process(pin, msg.payload);
-  				send_status_message(pin, node.topic + pin, msg.payload);
-				}
-				else {
-					node.warn("Topic should contain a valid pin in the rannge 0..15: [" + msg.topic+ "]");
-				}
-			}
-			this.status({fill:"green",shape:"dot",text:"Ready"});
-		});
+        function mcp23017_send_status() {
+            for (var pin = 0; pin < 16; pin++) {
+                mcp.digitalRead(pin, function(err, value) {
+                    node.log("Pin " + pin + " - " + value);
+                    var statusMsg = {};
+                    statusMsg.topic = node.topic + pin;
+                    statusMsg.payload = {
+                        pin: pin,
+                        value: (value) ? "OFF" : "ON"
+                    };
+                    node.send(statusMsg);
+                });
+            }
+        }
 
-		function send_status_message(pin, topic, state) {
-			var statusMsg = {}
-			statusMsg.topic   = topic + pin;
-			statusMsg.payload = "Sent " + state + " to relay "+ pin;
-			node.send(statusMsg);
-		}
+        function mcp23017_set_all_outputs(state) {
+            for (var pin = 0; pin < 16; pin++) {
+                mcp23017_process(pin, state);
+            }
+        }
 
-		function mcp23017_send_status() {
-			for (var pin =0; pin < 16; pin++) {
-				mcp.digitalRead(pin, function(err, value) {
-					node.log("Pin " + pin + " - " + value);
-					var statusMsg = {};
-					statusMsg.topic = node.topic + pin;
-					statusMsg.payload = { pin: pin, value: (value) ? "OFF" : "ON" };
-					node.send(statusMsg);
-				});
-				}
-			}
+        function mcp23017_process(pin, state) {
+            mcp.digitalWrite(pin, (state == "ON") ? mcp.LOW : mcp.HIGH);
+        }
 
-			function mcp23017_set_all_outputs(state) {
-				for (var pin = 0; pin < 16; pin++) {
-					mcp23017_process(pin, state);
-				}
-			}
+        function get_pin_from_topic(topic) {
+            var parts = topic.split('/');
+            var index = parts.length - 1;
+            return parseInt(parts[index]);
+        }
+    }
 
-			function mcp23017_process(pin, state) {
-				mcp.digitalWrite(pin, (state == "ON") ? mcp.LOW : mcp.HIGH );
-			}
-
-			function get_pin_from_topic(topic) {
-				var parts = topic.split('/');
-				var index = parts.length-1;
-				return parseInt(parts[index]) ;
-			}
-		}
-
-		RED.nodes.registerType("mcp23017", mcp23017_Node);
-	}
+    RED.nodes.registerType("mcp23017", mcp23017_Node);
+}

--- a/mcp23017/mcp23017.js
+++ b/mcp23017/mcp23017.js
@@ -78,16 +78,19 @@ module.exports = function(RED) {
 
         function mcp23017_send_status() {
             for (var pin = 0; pin < 16; pin++) {
-                mcp.digitalRead(pin, function(err, value) {
-                    node.log("Pin " + pin + " - " + value);
-                    var statusMsg = {};
-                    statusMsg.topic = node.topic + pin;
+
+                // mcp.pinMode(_pin, mcp.INPUT); //if you want them to be inputs
+                // mcp.pinMode(_pin, mcp.INPUT_PULLUP); //if you want them to be pullup inputs
+                mcp.digitalRead(_pin, function(pin, err, value) {
+
+                    var statusMsg = {}
+                    statusMsg.topic = node.topic + pin
                     statusMsg.payload = {
                         pin: pin,
-                        value: (value) ? "OFF" : "ON"
-                    };
-                    node.send(statusMsg);
-                });
+                        value: value ? 'OFF' : 'ON'
+                    }
+                    node.send(statusMsg)
+                })
             }
         }
 


### PR DESCRIPTION
node-mcp23017 closure issue caused mcp.digitalRead to always put pin to 16 (highest value). Update 0.0.5 of node-mcp23017  fixes this. That is why node-red-contrib-mcp23017 was changed accordingly. Tested with Raspberry Pi 3B+, mcp23017 with 8 inputs and 8 outputs. 

Note: it should also become easier to use this library for inputs I think, I did a hack for that but commented it out for now.